### PR TITLE
update helm charts 2023-08-28

### DIFF
--- a/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: aws-for-fluent-bit
                 # anything not staging or prod use this version
-                addonChartVersion: 0.1.28
+                addonChartVersion: 0.1.29
                 addonChartRepository: https://aws.github.io/eks-charts
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 0.1.28
+                addonChartVersion: 0.1.29
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 0.1.28
+                addonChartVersion: 0.1.29
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: argo-cd
                 # anything not staging or prod use this version
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
                 addonChartRepository: https://argoproj.github.io/argo-helm
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
   template:
     metadata:
       name: addon-{{name}}-aws-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-ingress-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-ingress-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: argo-cd
                 # anything not staging or prod use this version
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
                 addonChartRepository: https://argoproj.github.io/argo-helm
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
   template:
     metadata:
       name: addon-{{name}}-aws-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-cluster-autoscaler-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-cluster-autoscaler-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: cluster-autoscaler
                 # anything not staging or prod use this version
-                addonChartVersion: 9.29.1
+                addonChartVersion: 9.29.2
                 addonChartRepository: https://kubernetes.github.io/autoscaler
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 9.29.1
+                addonChartVersion: 9.29.2
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 9.29.1
+                addonChartVersion: 9.29.2
           - clusters:
               selector:
                 matchLabels:

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-external-secrets-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-external-secrets-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: external-secrets
                 # anything not staging or prod use this version
-                addonChartVersion: 0.9.3
+                addonChartVersion: 0.9.4
                 addonChartRepository: https://charts.external-secrets.io
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 0.9.3
+                addonChartVersion: 0.9.4
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 0.9.3
+                addonChartVersion: 0.9.4
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-velero-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-velero-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: velero
                 # anything not staging or prod use this version
-                addonChartVersion: 5.0.1
+                addonChartVersion: 5.0.2
                 addonChartRepository: https://vmware-tanzu.github.io/helm-charts
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 5.0.1
+                addonChartVersion: 5.0.2
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 5.0.1
+                addonChartVersion: 5.0.2
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/oss/addons-argo-cd-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-argo-cd-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: argo-cd
                 # anything not staging or prod use this version
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
                 addonChartRepositoryNamespace: argocd
                 addonChartRepository: https://argoproj.github.io/argo-helm
               selector:
@@ -30,13 +30,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 5.43.4
+                addonChartVersion: 5.45.0
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/oss/addons-kube-prometheus-stack-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-kube-prometheus-stack-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: kube-prometheus-stack
                 # anything not staging or prod use this version
-                addonChartVersion: 48.3.2
+                addonChartVersion: 49.0.0
                 addonChartRepository: https://prometheus-community.github.io/helm-charts
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 48.3.2
+                addonChartVersion: 49.0.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 48.3.2
+                addonChartVersion: 49.0.0
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/oss/addons-vpa-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-vpa-appset.yaml
@@ -14,7 +14,7 @@ spec:
               values:
                 addonChart: vpa
                 # anything not staging or prod use this version
-                addonChartVersion: 2.4.0
+                addonChartVersion: 2.5.1
                 addonChartRepository: https://charts.fairwinds.com/stable
               selector:
                 matchExpressions:
@@ -29,13 +29,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: 2.4.0
+                addonChartVersion: 2.5.1
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: 2.4.0
+                addonChartVersion: 2.5.1
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}


### PR DESCRIPTION
Newer version available for argo-cd: 5.45.0 (current: 5.43.4)
Newer version available for kube-prometheus-stack: 49.0.0 (current: 48.3.2)
Newer version available for vpa: 2.5.1 (current: 2.4.0)
Newer version available for aws-for-fluent-bit: 0.1.29 (current: 0.1.28)
Newer version available for cluster-autoscaler: 9.29.2 (current: 9.29.1)
Newer version available for external-secrets: 0.9.4 (current: 0.9.3)
Newer version available for velero: 5.0.2 (current: 5.0.1)