### PR TITLE
DEVOPS-2216 make argocd internal

### DIFF
--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-apigatewayv2-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-apigatewayv2-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-dynamodb-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-dynamodb-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-emrcontainers-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-emrcontainers-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-eventbridge-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-eventbridge-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-prometheusservice-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-prometheusservice-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-rds-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-rds-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-s3-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-s3-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-sfn-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/ack/addons-aws-ack-sfn-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-cloudwatch-metrics-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-cloudwatch-metrics-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-csi-ebs-resources-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-csi-ebs-resources-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-csi-efs-driver-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-csi-efs-driver-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-csi-fsx-driver-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-csi-fsx-driver-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-fargate-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-fluentbit-fargate-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-gateway-api-controller-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-gateway-api-controller-appset.yaml
@@ -44,7 +44,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChartReleaseName}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-load-balancer-controller-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-load-balancer-controller-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-node-termination-handler-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-node-termination-handler-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-argo-workflows-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-argo-workflows-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{.name}}-aws-{{.values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-hub-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-hub-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{.name}}-aws-{{.values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-ingress-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-argocd-ingress-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{.name}}-aws-{{.values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-cert-manager-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-cert-manager-appset.yaml
@@ -42,7 +42,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-cluster-autoscaler-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-cluster-autoscaler-appset.yaml
@@ -94,7 +94,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-crossplane-aws.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-crossplane-aws.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-crossplane-upbound.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-crossplane-upbound.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-external-dns-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: 'addon-{{.name}}-{{.values.addonChart}}'
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-external-secrets-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-external-secrets-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -60,7 +60,8 @@ spec:
               - $values/{{metadata.annotations.addons_repo_basepath}}clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
             values: |
               settings:
-                clusterName: {{metadata.annotations.aws_cluster_name}}
+                aws:
+                  clusterName: {{metadata.annotations.aws_cluster_name}}
                 interruptionQueue: {{metadata.annotations.karpenter_sqs_queue_name}}
               serviceAccount:
                 name: {{metadata.annotations.karpenter_service_account}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -43,7 +43,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -15,7 +15,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: v0.34.1
+                addonChartVersion: v0.31.3
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -32,13 +32,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: v0.34.1
+                addonChartVersion: v0.31.3
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: v0.34.1
+                addonChartVersion: v0.31.3
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -62,7 +62,7 @@ spec:
               settings:
                 aws:
                   clusterName: {{metadata.annotations.aws_cluster_name}}
-                interruptionQueue: {{metadata.annotations.karpenter_sqs_queue_name}}
+                  interruptionQueue: {{metadata.annotations.karpenter_sqs_queue_name}}
               serviceAccount:
                 name: {{metadata.annotations.karpenter_service_account}}
                 annotations:

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -15,7 +15,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: v0.16.3
+                addonChartVersion: v0.16.0
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -32,13 +32,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: v0.16.3
+                addonChartVersion: v0.16.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: v0.16.3
+                addonChartVersion: v0.16.0
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -15,7 +15,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: v0.16.0
+                addonChartVersion: v0.30.0
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -32,13 +32,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: v0.16.0
+                addonChartVersion: v0.30.0
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: v0.16.0
+                addonChartVersion: v0.30.0
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-karpenter-appset.yaml
@@ -15,7 +15,7 @@ spec:
                 addonChart: karpenter
                 addonChartReleaseName: karpenter
                 addonChartRepositoryNamespace: karpenter
-                addonChartVersion: v0.31.3
+                addonChartVersion: v0.16.3
                 # using oci repostory already configure in argocd
                 # argocd repo add public.ecr.aws --type helm --name aws-public-ecr --enable-oci
                 addonChartRepository: public.ecr.aws
@@ -32,13 +32,13 @@ spec:
                 matchLabels:
                   environment: staging
               values:
-                addonChartVersion: v0.31.3
+                addonChartVersion: v0.16.3
           - clusters:
               selector:
                 matchLabels:
                   environment: prod
               values:
-                addonChartVersion: v0.31.3
+                addonChartVersion: v0.16.3
   template:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-privateca-issuer-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-privateca-issuer-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-oss-velero-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-oss-velero-appset.yaml
@@ -42,7 +42,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/aws/addons-aws-secrets-store-csi-driver-provider-appset.yaml
+++ b/bootstrap/control-plane/addons/aws/addons-aws-secrets-store-csi-driver-provider-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-argo-cd-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-argo-cd-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'
@@ -56,6 +56,46 @@ spec:
               - $values/{{metadata.annotations.addons_repo_basepath}}environments/default/addons/{{values.addonChart}}/values.yaml
               - $values/{{metadata.annotations.addons_repo_basepath}}environments/{{metadata.labels.environment}}/addons/{{values.addonChart}}/values.yaml
               - $values/{{metadata.annotations.addons_repo_basepath}}environments/clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
+            valuesObject:
+              server:
+                ingress:
+                  enabled: true
+                  ingressClassName: alb
+                  hostname: "argocd.{{metadata.annotations.eks_cluster_domain}}"
+                  annotations:
+                    alb.ingress.kubernetes.io/backend-protocol: HTTPS
+                    alb.ingress.kubernetes.io/certificate-arn: "{{metadata.annotations.argocd_cert_arn}}"
+                    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+                    alb.ingress.kubernetes.io/healthcheck-protocol: HTTPS
+                    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+                    alb.ingress.kubernetes.io/scheme: internal
+                    alb.ingress.kubernetes.io/ssl-redirect: "443"
+                    alb.ingress.kubernetes.io/tags: Name=argocd-alb
+                    alb.ingress.kubernetes.io/target-type: ip
+                    external-dns.alpha.kubernetes.io/hostname: "argocd.{{metadata.annotations.eks_cluster_domain}}"
+                    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+                    provi.repository: https://github.com/Provi-Engineering/provi-eks-blueprints
+                    provi.slack: talk-devops
+                    external-dns.alpha.kubernetes.io/ttl: "10"
+                    external-dns.alpha.kubernetes.io/aws-weight: "{{metadata.annotations.route53_weight}}"
+                    external-dns.alpha.kubernetes.io/set-identifier: "{{metadata.annotations.cluster_name}}"
+              configs:
+                secret:
+                  extra:
+                    dex.github.clientID: "{{metadata.annotations.argocd_github_client_id}}"
+                    dex.github.clientSecret: "{{metadata.annotations.argocd_github_client_secret}}"
+                cm:
+                  url: "https://argocd.{{metadata.annotations.eks_cluster_domain}}"
+                  dex.config: |
+                    connectors:
+                      - type: github
+                        id: github
+                        name: GitHub
+                        config:
+                          clientID: $dex.github.clientID
+                          clientSecret: $dex.github.clientSecret
+                          orgs:
+                          - name: Provi-Engineering
       destination:
         namespace: '{{values.addonChartRepositoryNamespace}}'
         name: '{{name}}'

--- a/bootstrap/control-plane/addons/oss/addons-argo-events-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-argo-events-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-argo-rollouts-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-argo-rollouts-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-argo-workflows-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-argo-workflows-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{.name}}-{{.values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-cert-manager-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-cert-manager-appset.yaml
@@ -42,7 +42,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-cluster-proportional-autoscaler-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-cluster-proportional-autoscaler-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-crossplane-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-crossplane-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-crossplane-helm.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-crossplane-helm.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-crossplane-kubernetes.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-crossplane-kubernetes.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-gatekeeper-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-gatekeeper-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-gpu-operator-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-gpu-operator-appset.yaml
@@ -45,7 +45,7 @@ spec:
           kind: DaemonSet
           name: gpu-operator-node-feature-discovery-worker
           jsonPointers: [/metadata/annotations]
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-ingress-nginx-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{.name}}-{{.values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{.metadata.annotations.addons_repo_url}}'
           targetRevision: '{{.metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-kube-prometheus-stack-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-kube-prometheus-stack-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-kyverno-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-kyverno-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-metrics-server-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-metrics-server-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-prometheus-adapter-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-prometheus-adapter-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-secrets-store-csi-driver-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-secrets-store-csi-driver-appset.yaml
@@ -41,7 +41,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/addons/oss/addons-vpa-appset.yaml
+++ b/bootstrap/control-plane/addons/oss/addons-vpa-appset.yaml
@@ -40,7 +40,7 @@ spec:
     metadata:
       name: addon-{{name}}-{{values.addonChart}}
     spec:
-      project: default
+      project: addons
       sources:
         - repoURL: '{{metadata.annotations.addons_repo_url}}'
           targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/clusters/clusters-appset.yaml
+++ b/bootstrap/control-plane/clusters/clusters-appset.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: cluster-{{name}}
     spec:
-      project: default
+      project: addons
       source:
         repoURL: '{{metadata.annotations.addons_repo_url}}'
         targetRevision: '{{metadata.annotations.addons_repo_revision}}'

--- a/bootstrap/control-plane/exclude/bootstrap.yaml
+++ b/bootstrap/control-plane/exclude/bootstrap.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: 'bootstrap-addons'
     spec:
-      project: default
+      project: addons
       source:
         repoURL: '{{metadata.annotations.addons_repo_url}}'
         path: '{{metadata.annotations.addons_repo_basepath}}{{metadata.annotations.addons_repo_path}}'

--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -64,6 +64,44 @@ configs:
       type: helm
       url: public.ecr.aws
       enableOCI: 'true'
+    provi-helm-charts:
+      url: https://provi-helm-charts.pvfog.org
+      name: provi-helm-charts
+      type: helm
+    keda-core:
+      url: https://kedacore.github.io/charts
+      name: kedacore
+      type: helm
+    sumologic:
+      url: https://sumologic.github.io/sumologic-kubernetes-collection
+      name: sumologic
+      type: helm
+    datadog:
+      url: https://helm.datadoghq.com
+      name: datadog
+      type: helm
+
+  rbac:
+    policy.default: "role:dev"
+    policy.csv: |
+      p, role:dev, applications, get, default/*, allow
+      p, role:dev, applications, create, default/*, allow
+      p, role:dev, applications, update, default/*, allow
+      p, role:dev, applications, delete, default/*, allow
+      p, role:dev, applications, sync, default/*, allow
+      p, role:dev, applications, override, default/*, allow
+      p, role:dev, applications, action/*, default/*, allow
+      p, role:dev, exec, create, default/*, allow
+      p, role:dev, certificates, get, default/*, allow
+      p, role:dev, clusters, get, default/*, allow
+      p, role:dev, repositories, get, default/*, allow
+      p, role:dev, projects, get, default/*, allow
+      p, role:dev, accounts, get, default/*, allow
+      p, role:dev, gpgkeys, get, default/*, allow
+      p, role:dev, logs, get, default/*, allow
+
+      g, Provi-Engineering:DevOps, role:admin
+
   cm:
     application.resourceTrackingMethod: 'annotation' #use annotation for tracking required for Crossplane
     resource.exclusions: |

--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -65,7 +65,7 @@ configs:
       url: public.ecr.aws
       enableOCI: 'true'
     provi-helm-charts:
-      url: https://provi-helm-charts.pvfog.org
+      url: https://provi-engineering.github.io/helm-charts
       name: provi-helm-charts
       type: helm
     keda-core:

--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -103,6 +103,7 @@ configs:
       g, Provi-Engineering:DevOps, role:admin
 
   cm:
+    accounts.ci: apiKey
     application.resourceTrackingMethod: 'annotation' #use annotation for tracking required for Crossplane
     resource.exclusions: |
       - kinds:

--- a/environments/default/addons/argo-cd/values.yaml
+++ b/environments/default/addons/argo-cd/values.yaml
@@ -54,7 +54,7 @@ server:
     type: LoadBalancer
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internal
 
 configs:
   repositories:


### PR DESCRIPTION
We are using `kubectl port-forward` to access ArgoCD within CircleCI, so we shouldn't need to make ArgoCD `internet-facing`.